### PR TITLE
Update identify-endpoints-where-mitigationstatus-is-isolated.md

### DIFF
--- a/03.SecOps/identify-endpoints-where-mitigationstatus-is-isolated.md
+++ b/03.SecOps/identify-endpoints-where-mitigationstatus-is-isolated.md
@@ -6,21 +6,24 @@ The following query will leverage the DeviceInfo table and identify endpoints wh
 
 ### Microsoft Defender XDR
 ```
-let Timeframe = 1h; // Choose the best timeframe for your investigation
+```
+let Timeframe = 4h; // Choose the best timeframe for your investigation
 DeviceInfo
-| where TimeGenerated > ago(Timeframe)
+| where Timestamp > ago(Timeframe)
+| summarize arg_max(Timestamp, *) by DeviceId //only look at the most recent entry
 | extend DeviceUser = parse_json(LoggedOnUsers)
 | mv-expand DeviceUser
 | extend LoggedOnUsername = tostring(DeviceUser.UserName)
 | extend LoggedOnDomainName = tostring(DeviceUser.DomainName)
 | extend MitigationStatusObject = parse_json(MitigationStatus)
 | mv-expand MitigationStatusObject
-| extend IsolationStatus = MitigationStatusObject.Isolated
+| extend IsolationStatus = tostring(MitigationStatusObject.Isolated)
 | where IsolationStatus == "true"
-| distinct DeviceId, DeviceName, OSPlatform, LoggedOnUsername, LoggedOnDomainName, Isolation = "Yes"
+| project Timestamp, DeviceId, DeviceName, OSPlatform, LoggedOnUsername, LoggedOnDomainName, IsolationStatus
 ```
 
 ### Versioning
-| Version       | Date          | Comments                               |
-| ------------- |---------------| ---------------------------------------|
-| 1.0           | 27/04/2024    | Initial publish                        |
+| Version       | Date          | Comments                                                                            |
+| ------------- |---------------| ------------------------------------------------------------------------------------|
+| 1.0           | 27/04/2024    | Initial publish                                                                     |
+| 1.1           | 01/05/2024    | Only show Devices where the most recent entry of the Table hast the isolated status |


### PR DESCRIPTION
This is just a small suggestion for the query to only show the most recent entry for a device in the DeviceInfo table.