### PR TITLE
Update identify-endpoint-browser-extensions-with-can-turnoff-malware-…

### DIFF
--- a/02.ThreatDetection/identify-endpoint-browser-extensions-with-can-turnoff-malware-protections-permissions.md
+++ b/02.ThreatDetection/identify-endpoint-browser-extensions-with-can-turnoff-malware-protections-permissions.md
@@ -12,23 +12,19 @@ let BrowserExtMalwareProtectionKB = DeviceTvmBrowserExtensionsKB
 let BrowserExtMalwareProtection = DeviceTvmBrowserExtensions
     | project ExtensionId, DeviceId;
 let DeviceInformation = DeviceInfo
-    | project DeviceId, DeviceName;
+    | project DeviceId, DeviceName, Timestamp;
 union BrowserExtMalwareProtection, BrowserExtMalwareProtectionKB,
         DeviceInformation
     | summarize by ExtensionId, DeviceId
     | join ( BrowserExtMalwareProtectionKB ) on ExtensionId
     | join kind=rightouter ( BrowserExtMalwareProtection ) on ExtensionId
     | join ( DeviceInformation ) on DeviceId
-    | project ExtensionId,
-        ExtensionName,
-        ExtensionRisk,
-        PermissionName,
-        DeviceId,
-        DeviceName
-    | summarize by DeviceName, ExtensionName, ExtensionRisk
+    | summarize DeviceCount=dcount(DeviceName), arg_max(Timestamp, *) by ExtensionName, ExtensionRisk
+    | sort by DeviceCount asc, ExtensionRisk
 ```
 
 ### Versioning
 | Version       | Date          | Comments                               |
 | ------------- |---------------| ---------------------------------------|
 | 1.0           | 29/08/2024    | Initial publish                        |
+| 1.1           | 29/08/2024    | Refinement                        |


### PR DESCRIPTION
…protections-permissions.md

- Removed a redundant project before the summarize
- Added Timestamp from DeviceInfo
- Shows DeviceCount (prevalance indicator) per Extension keeping the latest seen device